### PR TITLE
feat: Implement strictly monotonic UUIDv7 generator

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
             DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
                     Version 2, December 2004
 
- Copyright (C) 2024 0xShamil
+ Copyright (C) 2025 0xShamil
 
  Everyone is permitted to copy and distribute verbatim or modified
  copies of this license document, and changing it is allowed as long

--- a/README.md
+++ b/README.md
@@ -1,24 +1,41 @@
 # Kotlin UUIDv7 Generator
 
-A zero dependency, dead simple version 7 UUID generator in 40 lines or less.
-
-## Features
-
-- **Zero Dependencies:** The entire implementation is under 40 lines and requires no external dependencies.
-- **Timestamp-based UUIDs:** Embeds the current timestamp in milliseconds into the UUID for ordering.
-- **Randomness and Uniqueness:** Uses `SecureRandom` to generate high-entropy random bits.
-- **Standards Compliance:** Sets the correct version and variant bits according to the UUIDv7 draft specification.
-- **Easy Integration:** Provides a singleton object `UUIDv7` with a simple `randomUUID()` method.
+A dependency-free, high-performance, monotonic UUID v7 generator in 60 lines or less.
 
 ## Usage
 
-Just copy the `UUIDv7.kt` file to your project.
+Just copy `UUIDv7.kt` into your project and call `UUIDv7.randomUUID()`.
 
 ```kotlin
 import UUIDv7
 
 fun main() {
-    val uuid = UUIDv7.randomUUID()
-    println(uuid) // 01923d43-13b4-7f90-b304-cf0ca680b6c5
+    val id: UUID = UUIDv7.randomUUID()
+    println(id) // 0192f5cd-0c2e-7a3f-b1d2-8b9a6d2b4c11
 }
 ```
+
+## K-Sortability
+
+By design, all Version 7 UUIDs are naturally sortable by the millisecond in which they were created, because the
+timestamp is placed at the very beginning of the identifier. This implementation enhances this property even further. It
+guarantees that UUIDs generated within the exact same millisecond are also perfectly ordered relative to each other. It
+achieves this by using a special 12-bit monotonic counter that increments for each new UUID created in that millisecond.
+This results in a continuous stream of UUIDs that are always in a strict, lexicographical order.
+
+*Note: The per-millisecond ordering is backed by a 12-bit counter. That means up to 4096 UUIDs per millisecond can be
+strictly ordered. If more than 4096 UUIDs are generated within the same millisecond, the counter wraps and strict
+monotonicity for that millisecond is no longer guaranteed.*
+
+## High Performance
+
+The generator is intended for use in performance-critical code paths where high throughput is required. The code avoids
+unnecessary work and keeps contention low:
+
+A per-thread `SecureRandom` to remove global RNG locks. The monotonic state is managed using Atomic variables in a
+non-blocking loop, which avoids the overhead and contention of traditional locks. The byte layout is written directly
+with simple shifts and masks; version/variant bits are set in place with minimal branching.
+
+## License
+
+This code is available under an [WTFPL License](https://github.com/0xShamil/uuidv7-kotlin/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ fun main() {
 ## K-Sortability
 
 By design, all Version 7 UUIDs are naturally sortable by the millisecond in which they were created, because the
-timestamp is placed at the very beginning of the identifier. This implementation enhances this property even further. It
+timestamp is placed at the very beginning of the identifier. This implementation takes this property even further. It
 guarantees that UUIDs generated within the exact same millisecond are also perfectly ordered relative to each other. It
 achieves this by using a special 12-bit monotonic counter that increments for each new UUID created in that millisecond.
 This results in a continuous stream of UUIDs that are always in a strict, lexicographical order.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "2.0.20"
+    kotlin("jvm") version "2.2.20"
 }
 
 group = "fyi.shamil"
@@ -17,5 +17,5 @@ tasks.test {
     useJUnitPlatform()
 }
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(24)
 }

--- a/src/main/kotlin/UUIDv7.kt
+++ b/src/main/kotlin/UUIDv7.kt
@@ -16,18 +16,24 @@
 
 import java.security.SecureRandom
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 
 object UUIDv7 {
-    private val numberGenerator = SecureRandom()
+    private val numberGenerator: ThreadLocal<SecureRandom> = ThreadLocal.withInitial { SecureRandom() }
+
+    // Shared monotonic states
+    private val lastMillis = AtomicLong(Long.MIN_VALUE)
+    private val lastSeq12 = AtomicInteger(-1)
 
     /**
      * @return A UUID object representing a UUIDv7 value.
      */
     fun randomUUID(): UUID {
-        val value = randomBytes()
-        val high = value.toLong(0)
-        val low = value.toLong(8)
-        return UUID(high, low)
+        val bytes = randomBytesMonotonic()
+        val msb = bytes.toLongBE(0)
+        val lsb = bytes.toLongBE(8)
+        return UUID(msb, lsb)
     }
 
     /**
@@ -35,21 +41,38 @@ object UUIDv7 {
      * The first 6 bytes contain the current timestamp in milliseconds.
      * The next bytes are random, with specific bits set for version and variant.
      *
+     * Layout:
+     *  - [0..5]   : 48-bit Unix epoch milliseconds (timestamp)
+     *  - [6]      : high nibble = version 7, low nibble = rand_a[11:8]
+     *  - [7]      : rand_a[7:0] (12-bit monotonic sequence, wraps mod 4096)
+     *  - [8]      : IETF variant in high 2 bits, lower 6 bits random
+     *  - [9..15]  : remaining 62 bits of randomness across [8..15], except variant bits
+     *
+     *
      * @return A ByteArray of 16 bytes representing the UUIDv7.
      */
-    private fun randomBytes(): ByteArray {
-        val value = ByteArray(16).also { numberGenerator.nextBytes(it) }
+    private fun randomBytesMonotonic(): ByteArray {
+        val value = ByteArray(16).also { numberGenerator.get().nextBytes(it) }
 
-        val timestamp = System.currentTimeMillis()
-        value[0] = ((timestamp shr 40) and 0xFF).toByte()
-        value[1] = ((timestamp shr 32) and 0xFF).toByte()
-        value[2] = ((timestamp shr 24) and 0xFF).toByte()
-        value[3] = ((timestamp shr 16) and 0xFF).toByte()
-        value[4] = ((timestamp shr 8) and 0xFF).toByte()
-        value[5] = (timestamp and 0xFF).toByte()
+        val now = System.currentTimeMillis()
+        val prev = lastMillis.get()
+        val ts = if (now >= prev) now else prev // clamp to avoid regressions
 
-        // Set the version to 7
-        value[6] = ((value[6].toInt() and 0x0F) or 0x70).toByte()
+        value[0] = ((ts ushr 40) and 0xFF).toByte()
+        value[1] = ((ts ushr 32) and 0xFF).toByte()
+        value[2] = ((ts ushr 24) and 0xFF).toByte()
+        value[3] = ((ts ushr 16) and 0xFF).toByte()
+        value[4] = ((ts ushr 8) and 0xFF).toByte()
+        value[5] = (ts and 0xFF).toByte()
+
+        // If same millisecond as last call, increment 12-bit counter else reseed
+        val seq: Int = nextSeq(ts)
+
+        // Set the version to 7 in high nibble of byte 6
+        value[6] = (((0x7 shl 4) or ((seq ushr 8) and 0x0F))).toByte()
+
+        // Set low 8 bits of rand_a in byte 7
+        value[7] = (seq and 0xFF).toByte()
 
         // Set the variant to IETF variant
         value[8] = ((value[8].toInt() and 0x3F) or 0x80).toByte()
@@ -57,18 +80,45 @@ object UUIDv7 {
         return value
     }
 
-    /**
-     * @param offset The starting index in the ByteArray.
-     * @return A Long value constructed from 8 bytes starting at the given offset.
-     */
-    private fun ByteArray.toLong(offset: Int = 0): Long {
-        return ((this[offset].toLong() and 0xFF) shl 56) or
-                ((this[offset + 1].toLong() and 0xFF) shl 48) or
-                ((this[offset + 2].toLong() and 0xFF) shl 40) or
-                ((this[offset + 3].toLong() and 0xFF) shl 32) or
-                ((this[offset + 4].toLong() and 0xFF) shl 24) or
-                ((this[offset + 5].toLong() and 0xFF) shl 16) or
-                ((this[offset + 6].toLong() and 0xFF) shl 8) or
+    // Big-endian 8-byte to long
+    private fun ByteArray.toLongBE(offset: Int = 0): Long {
+        return (this[offset].toLong() and 0xFF shl 56) or
+                (this[offset + 1].toLong() and 0xFF shl 48) or
+                (this[offset + 2].toLong() and 0xFF shl 40) or
+                (this[offset + 3].toLong() and 0xFF shl 32) or
+                (this[offset + 4].toLong() and 0xFF shl 24) or
+                (this[offset + 5].toLong() and 0xFF shl 16) or
+                (this[offset + 6].toLong() and 0xFF shl 8) or
                 (this[offset + 7].toLong() and 0xFF)
+    }
+
+    /**
+     * Returns the 12-bit monotonic sequence for the given millisecond:
+     * - If [ts] differs from the last seen timestamp, seed with a random 12-bit value.
+     * - If [ts] matches, increment modulo 4096 to preserve order for same-ms calls.
+     *
+     * Uses CAS on [lastMillis]/[lastSeq12] to remain lock-light under contention.
+     */
+    private fun nextSeq(ts: Long): Int {
+        while (true) {
+            val lastTs = lastMillis.get()
+            val lastSeq = lastSeq12.get()
+
+            if (ts != lastTs) {
+                // New millisecond: randomize the starting point to retain entropy
+                val seeded = numberGenerator.get().nextInt(1 shl 12)
+                if (lastMillis.compareAndSet(lastTs, ts)) {
+                    lastSeq12.set(seeded)
+                    return seeded
+                }
+            } else {
+                // Same millisecond: increment and wrap in 12 bits
+                val next = (lastSeq + 1) and 0x0FFF
+                if (lastSeq12.compareAndSet(lastSeq, next)) {
+                    return next
+                }
+            }
+            // If either CAS fails, retry with fresh reads
+        }
     }
 }

--- a/src/test/kotlin/UUIDv7Test.kt
+++ b/src/test/kotlin/UUIDv7Test.kt
@@ -19,6 +19,10 @@ import java.util.UUID
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 class UUIDv7Test {
 
@@ -65,6 +69,182 @@ class UUIDv7Test {
 
         // Since UUIDv7 includes the timestamp, uuid2 should be greater than uuid1
         assertTrue(uuid1 < uuid2) { "UUIDs are not ordered correctly" }
+    }
+
+    @Test
+    fun `test monotonicity within the same millisecond`() {
+        val window = mutableListOf<UUID>()
+        var lastTs = -1L
+
+        // Generate until we get a window of >= 5 with identical timestamp
+        repeat(50_000) {
+            val u = UUIDv7.randomUUID()
+            val ts = extractTimestamp(u)
+            if (window.isEmpty()) {
+                window.add(u)
+                lastTs = ts
+            } else if (ts == lastTs) {
+                window.add(u)
+            } else {
+                if (window.size >= 5) return@repeat
+                window.clear()
+                window.add(u)
+                lastTs = ts
+            }
+        }
+
+        assertTrue(window.size >= 5, "Failed to capture enough UUIDs in the same millisecond")
+
+        // rand_a should strictly increase for same-ms sequence until a wrap
+        val seqs = window.map { extractRandA(it) }
+        for (i in 1 until seqs.size) {
+            assertTrue(seqs[i] > seqs[i - 1], "rand_a did not increase within the same millisecond")
+        }
+
+        // Lexicographic UUID order should also increase
+        for (i in 1 until window.size) {
+            assertTrue(window[i - 1] < window[i], "UUIDs not strictly increasing within same ms")
+        }
+    }
+
+    @Test
+    fun `test monotonicity across milliseconds`() {
+        val u1 = UUIDv7.randomUUID()
+
+        // busy-wait until the next millisecond to avoid sleep granularity
+        val ts1 = extractTimestamp(u1)
+
+        var u2: UUID
+        while (true) {
+            u2 = UUIDv7.randomUUID()
+            if (extractTimestamp(u2) > ts1) break
+        }
+
+        assertTrue(u1 < u2, "UUID with later millisecond should be greater")
+    }
+
+
+    /** 12-bit rand_a is split as: byte6 low-nibble = high 4 bits, byte7 = low 8 bits. */
+    private fun extractRandA(uuid: UUID): Int {
+        val msb = uuid.mostSignificantBits
+        // Recreate bytes 6 and 7 from MSB
+        // MSB layout (bits): [0..63] is bytes 0..7
+        // We need byte6 (bits 16..23 of MSB) and byte7 (bits 24..31 of MSB) if using big-endian packing
+        val bytes = ByteArray(16)
+        val buf = ByteBuffer.wrap(bytes)
+        buf.putLong(msb)
+        buf.putLong(uuid.leastSignificantBits)
+        val b6 = bytes[6].toInt() and 0xFF
+        val b7 = bytes[7].toInt() and 0xFF
+        val high4 = b6 and 0x0F
+        return (high4 shl 8) or b7
+    }
+
+    @Test
+    fun `rand_a stays within 12-bit range`() {
+        repeat(10_000) {
+            val u = UUIDv7.randomUUID()
+            val seq = extractRandA(u)
+            assertTrue(seq in 0..0x0FFF, "rand_a out of 12-bit range: $seq")
+        }
+    }
+
+    @Test
+    fun `test concurrent generation yields no duplicates and global non-decreasing after sort`() {
+        val threads = Runtime.getRuntime().availableProcessors().coerceAtLeast(4)
+        val perThread = 12_000 / threads
+        val pool = Executors.newFixedThreadPool(threads)
+
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(threads)
+
+        val list = Collections.synchronizedList(mutableListOf<UUID>())
+
+        repeat(threads) {
+            pool.execute {
+                start.await()
+                repeat(perThread) { list += UUIDv7.randomUUID() }
+                done.countDown()
+            }
+        }
+
+        // start together
+        start.countDown()
+        assertTrue(done.await(30, TimeUnit.SECONDS), "Workers did not finish in time")
+        pool.shutdownNow()
+
+        // 1) No duplicates
+        val set = list.toSet()
+        assertEquals(list.size, set.size, "Duplicate UUIDs detected in concurrent generation")
+
+        // 2) Global non-decreasing when sorted by natural UUID order
+        val sorted = list.sorted()
+        for (i in 1 until sorted.size) {
+            assertTrue(sorted[i - 1] <= sorted[i], "Global order regressed at index $i")
+        }
+    }
+
+    @Test
+    fun `test concurrent generation - same-ms groups strictly increase by rand_a and match UUID order`() {
+        val threads = Runtime.getRuntime().availableProcessors().coerceAtLeast(4)
+        val perThread = 10_000 / threads
+        val pool = Executors.newFixedThreadPool(threads)
+
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(threads)
+
+        val uuids = Collections.synchronizedList(mutableListOf<UUID>())
+        repeat(threads) {
+            pool.execute {
+                start.await()
+                repeat(perThread) { uuids += UUIDv7.randomUUID() }
+                done.countDown()
+            }
+        }
+
+        start.countDown()
+        assertTrue(done.await(30, TimeUnit.SECONDS))
+        pool.shutdownNow()
+
+        // Group by embedded timestamp
+        val byTs: Map<Long, List<UUID>> = uuids.groupBy(::extractTimestamp)
+
+        // For each timestamp:
+        //  - rand_a values are unique
+        //  - sorting by rand_a equals sorting by UUID (because version nibble is constant and rand_a sits before rand_b)
+        //  - UUIDs are strictly increasing when ordered by rand_a
+        for ((ts, group) in byTs) {
+            if (group.size <= 1) continue
+
+            val withSeq = group.map { it to extractRandA(it) }
+            val seqs = withSeq.map { it.second }
+
+            // uniqueness of 12-bit counter in observed set
+            assertEquals(seqs.size, seqs.toSet().size, "Duplicate rand_a within ts=$ts")
+
+            // sort by seq and by UUID and compare order
+            val bySeq = withSeq.sortedBy { it.second }.map { it.first }
+            val byUuid = group.sorted()
+
+            assertEquals(bySeq, byUuid, "Within ts=$ts, UUID order does not match rand_a order")
+
+            // strictly increasing by UUID when ordered by seq
+            for (i in 1 until bySeq.size) {
+                assertTrue(bySeq[i - 1] < bySeq[i], "Within ts=$ts, UUIDs not strictly increasing")
+            }
+        }
+    }
+
+    @Test
+    fun `across milliseconds - later timestamp yields greater UUID`() {
+        val u1 = UUIDv7.randomUUID()
+        val ts1 = extractTimestamp(u1)
+        var u2: UUID
+        do {
+            u2 = UUIDv7.randomUUID()
+        } while (extractTimestamp(u2) == ts1)
+
+        assertTrue(u1 < u2, "UUID with later millisecond should be greater")
     }
 
     private fun extractTimestamp(uuid: UUID): Long {


### PR DESCRIPTION
This enhances our UUIDv7 generator to be strictly monotonic and improves performance under high-concurrent environment.

- Add 12-bit per-ms counter for monotonic ordering within the same millisecond
- Clamp clock regressions (`max(now, lastMillis)`) to keep ordering stable if time jumps back
- Use `ThreadLocal<SecureRandom>` and CAS for lock-light concurrency

This should result in truly k-sortable v7 UUIDs